### PR TITLE
Excluded dependabot from Deployment and Integration

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -20,9 +20,11 @@ on:
 
 jobs:
   secrets:
+    if: ${{ github.actor != 'dependabot[bot]' }}
     uses: bn-digital/vault/.github/workflows/import-secrets.yml@latest
     secrets: inherit
   deploy:
-    needs: [ secrets ]
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    needs: [secrets]
     uses: bn-digital/helm/.github/workflows/deploy-charts.yml@latest
     secrets: inherit

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -23,9 +23,11 @@ on:
 
 jobs:
   setup:
+    if: ${{ github.actor != 'dependabot[bot]' }}
     uses: bn-digital/vault/.github/workflows/import-secrets.yml@latest
     secrets: inherit
   build:
-    needs: [ setup ]
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    needs: [setup]
     uses: bn-digital/docker/.github/workflows/build-images.yml@latest
     secrets: inherit


### PR DESCRIPTION
**Perhaps this is a very extreme solution, but now the bot is working and it is possible to update dependencies automatically.**